### PR TITLE
README.md: mention cloudflare OpenWrt package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # cloudflared for OpenWrt
 
+> [!NOTE]  
+> The OpenWrt packages feed now has the `cloudflared` package and Luci Application `luci-app-cloudflared` that provides a GUI for configuration.
+> You can install them with the command `opkg install cloudflared luci-app-cloudflared`
+
+
 Really convenient for exposing services behind NAT.
 
 See [https://developers.cloudflare.com/cloudflare-one/connections/connect-apps](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps) for details.


### PR DESCRIPTION
The official package is available starting from version 23.03 https://github.com/openwrt/packages/tree/master/net/cloudflared
You can completely replace your package with the official.

Currently there is a problem that on the latest snapshot version it can't be compiled but that problem will be solved soon.
Also please check this [PR for a Luci App](https://github.com/openwrt/luci/pull/6876) that also should be merged soon.
Please test it and contribute.


Also please check the Wiki: 
https://openwrt.org/docs/guide-user/services/vpn/cloudfare_tunnel

@rsmnarts @jirijanata @Fummowo you guys can migrate to the official package

